### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: build code image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/aioshadowsocks
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: build-runtime-image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/aioshadowsocks
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: build-runtime-image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/aioshadowsocks
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -17,7 +17,7 @@ jobs:
           tags: "runtime"
           dockerfile: Dockerfile
       - name: build-tag-image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ehco1996/aioshadowsocks
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore